### PR TITLE
BREAKING: change API to be more similar to webtorrent

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,29 +1,35 @@
-var EventEmitter = require('events')
-var crypto = require('crypto')
-
-// Provides the WebTorrent API.
-// Talks to a WebTorrentRemoteServer instance in another process or even another machine.
-// Contains:
-// - a subset of the methods and props of the WebTorrent client object
-// - clientKey, the UUID that's included in all IPC messages to and from this client
-// - torrents, a map from torrent key (also a UUID) to torrent handle
-//
-// Constructor creates the client and introduces it to the server.
-// - send should be a function (message) {...} that passes the message to WebTorrentRemoteServer
-// - options optionally specifies {heartbeat}, the heartbeat interval in milliseconds
 module.exports = WebTorrentRemoteClient
 
-function WebTorrentRemoteClient (send, options) {
+var EventEmitter = require('events')
+
+/**
+* Provides the WebTorrent API.
+* Talks to a WebTorrentRemoteServer instance in another process or even another machine.
+* Contains:
+* - a subset of the methods and props of the WebTorrent client object
+* - clientKey, the UUID that's included in all IPC messages to and from this client
+* - torrents, a map from torrent key (also a UUID) to torrent handle
+*
+* Constructor creates the client and introduces it to the server.
+* - send should be a function (message) {...} that passes the message to WebTorrentRemoteServer
+* - opts optionally specifies {heartbeat}, the heartbeat interval in milliseconds
+*/
+
+function WebTorrentRemoteClient (send, opts) {
   EventEmitter.call(this)
+  if (!opts) opts = {}
+
+  this._send = send
+
   this.clientKey = generateUniqueKey()
   this.torrents = {}
-  this._send = send
-  this._options = options || {}
+
   this._destroyed = false
 
-  var heartbeat = this._options.heartbeat
-  if (heartbeat == null) heartbeat = 5000
-  if (heartbeat > 0) setInterval(sendHeartbeat.bind(null, this), heartbeat)
+  var heartbeat = opts.heartbeat != null ? opts.heartbeat : 5000
+  if (heartbeat > 0) {
+    this._interval = setInterval(sendHeartbeat.bind(null, this), heartbeat)
+  }
 }
 
 WebTorrentRemoteClient.prototype = Object.create(EventEmitter.prototype)
@@ -68,44 +74,50 @@ WebTorrentRemoteClient.prototype.receive = function (message) {
 
 // Gets an existing torrent. Returns a torrent handle.
 // Emits either the `torrent-present` or `torrent-absent` event on that handle.
-WebTorrentRemoteClient.prototype.get = function (torrentID, callback) {
+WebTorrentRemoteClient.prototype.get = function (torrentId, callback) {
   var torrentKey = generateUniqueKey()
   this._send({
     type: 'subscribe',
     clientKey: this.clientKey,
     torrentKey: torrentKey,
-    torrentID: torrentID
+    torrentId: torrentId
   })
   subscribeTorrentKey(this, torrentKey, callback)
 }
 
 // Adds a new torrent. See [client.add](https://webtorrent.io/docs)
-// - torrentID is a magnet link, etc
-// - options can contain {announce, path, ...}
+// - torrentId is a magnet link, etc
+// - opts can contain {announce, path, ...}
 // All parameters should be JSON serializable.
 // Returns a torrent handle.
-WebTorrentRemoteClient.prototype.add = function (torrentID, callback, options) {
-  options = options || {}
-  var torrentKey = options.torrentKey || generateUniqueKey()
+WebTorrentRemoteClient.prototype.add = function (torrentId, callback, opts) {
+  if (!opts) opts = {}
+  var torrentKey = opts.torrentKey || generateUniqueKey()
   this._send({
     type: 'add-torrent',
     clientKey: this.clientKey,
     torrentKey: torrentKey,
-    torrentID: torrentID,
-    options: options
+    torrentId: torrentId,
+    opts: opts
   })
   subscribeTorrentKey(this, torrentKey, callback)
 }
 
 // Destroys the client
 // If this was the last client for a given torrent, destroys that torrent too
-WebTorrentRemoteClient.prototype.destroy = function (options) {
+WebTorrentRemoteClient.prototype.destroy = function (opts) {
+  if (this._destroyed) return
+  this._destroyed = true
+
   this._send({
     type: 'destroy',
     clientKey: this.clientKey,
-    options: options
+    opts: opts
   })
-  this._destroyed = true
+
+  clearInterval(this._interval)
+  this._interval = null
+  this._send = null
 }
 
 // Refers to a WebTorrent torrent object that lives in a different process.
@@ -141,15 +153,15 @@ function RemoteTorrent (client, key) {
 RemoteTorrent.prototype = Object.create(EventEmitter.prototype)
 
 // Creates a streaming torrent-to-HTTP server
-// - options can contain {headers, ...}
+// - opts can contain {headers, ...}
 // All parameters should be JSON serializable.
-RemoteTorrent.prototype.createServer = function (options, callback) {
+RemoteTorrent.prototype.createServer = function (opts, callback) {
   this._serverReadyCallback = callback
   this.client._send({
     type: 'create-server',
     clientKey: this.client.clientKey,
     torrentKey: this.key,
-    options: options
+    opts: opts
   })
 }
 
@@ -197,7 +209,7 @@ function handleSubscribed (client, message) {
     Object.assign(torrent, message.torrent) // Fill in infohash, etc
     cb(null, torrent)
   } else {
-    var err = new Error('TorrentID not found: ' + message.torrentID)
+    var err = new Error('TorrentId not found: ' + message.torrentId)
     err.name = 'TorrentMissingError'
     delete client.torrents[message.torrentKey]
     cb(err)

--- a/client.js
+++ b/client.js
@@ -211,5 +211,5 @@ function getTorrentByKey (client, torrentKey) {
 }
 
 function generateUniqueKey () {
-  return crypto.randomBytes(16).toString('hex')
+  return Math.random().toString(16).slice(2)
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "standard": "*"
   },
   "dependencies": {
+    "debug": "^2.6.3",
     "webtorrent": "0.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/dcposch/webtorrent-remote#readme",
   "devDependencies": {
-    "standard": "^8.5.0"
+    "standard": "*"
   },
   "dependencies": {
     "webtorrent": "0.x"


### PR DESCRIPTION
Huge PR, sorry for that. This supports http torrent links in Brave.

- Change `client.add(torrentID, callback, options)` to `client.add(torrentID, options, callback)`

- Remove non-standard `server` option from `client.add()`

- Remove `trace` option from server constructor (use `debug` module like other webtorrent modules)

- Change `torrent.createServer()` to return a server object, and now it takes no arguments

- add `server.address()` and `server.listen()` methods

- remove `delay` option from `client.destroy()` (client automatically handles delayed destruction)

- Fixes the "unknown message for clientKey" that happens in Brave when navigating to another page. Used to happen because when the {delay: 5000} option was used, the client wasn't removed from the torrent right away, which caused 'update' messages to continue getting sent.

- I removed the `delay` option, now the client is always removed right away from the torrent. But the torrent isn't destroyed for 10s, giving time for another client to connect. If a client connects in that time, the torrent is not destroyed.

- This is nice, because now it matches the WebTorrent API more closely, which doesn't have a `delay` option.

- Refactored `killClients()` to just kill a single client `killClient()`