### PR TITLE
Use localhost instead of unspecified address

### DIFF
--- a/server.js
+++ b/server.js
@@ -200,7 +200,7 @@ function handleCreateServer (server, message) {
     // Server does not yet exist. Create it, then notify everyone who asked for it
     torrent.pendingServerCallbacks = [done]
     torrent.server = torrent.createServer(opts)
-    torrent.server.listen(function () {
+    torrent.server.listen(undefined, 'localhost', undefined, function () {
       torrent.serverAddress = torrent.server.address()
       torrent.pendingServerCallbacks.forEach(function (cb) { cb() })
       delete torrent.pendingServerCallbacks


### PR DESCRIPTION
for the local webtorrent server. Fix #7

Note: 'localhost' is used instead of '127.0.0.1' so that the server is reachable on ipv6-only machines.

Reference: https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback

STR for the original issue:
1. Launch a webtorrent app such as Brave and click on a torrent file
2. Open devtools to see what $PORT the webtorrent files are served from
3. Use ifconfig or another tool to see what your local $HOST_IP address is, ex: 192.168.1.1
4. Open a browser and navigate to `http://$HOST_IP:$PORT`. You can see what files are being downloaded by webtorrent.

What should happen with this fix:
Repeat steps 1-4. In step 4, `http://$HOST_IP:$PORT` should be unreachable.
